### PR TITLE
Update npm install command to use "npm ci"

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ UNDER PROGESS REACT PORTFOLIO
 ```bash
 git clone https://github.com/tomsabu444/My-React_Portfolio.git
 cd My-React_Portfolio
-npm i
+npm ci
 npm run dev
 ```
 


### PR DESCRIPTION
This pull request updates the npm install command in the project to use "npm ci" instead of "npm i". This change ensures that the project's dependencies are installed based on the package-lock.json file, providing deterministic and reproducible builds.